### PR TITLE
[OpenMP] Support library runtime functions 

### DIFF
--- a/TaffoInitializer/CMakeLists.txt
+++ b/TaffoInitializer/CMakeLists.txt
@@ -7,8 +7,8 @@ add_llvm_library(${SELF} OBJECT BUILDTREE_ONLY
   IndirectCallPatcher.cpp
 
   ADDITIONAL_HEADERS
-  AnnotationParser.h
   TaffoInitializerPass.h
+  AnnotationParser.h
   IndirectCallPatcher.h
 )
 target_link_libraries(obj.${SELF} PUBLIC

--- a/TaffoInitializer/CMakeLists.txt
+++ b/TaffoInitializer/CMakeLists.txt
@@ -4,10 +4,12 @@ add_llvm_library(${SELF} OBJECT BUILDTREE_ONLY
   TaffoInitializerPass.cpp
   Annotations.cpp
   AnnotationParser.cpp
+  IndirectCallPatcher.cpp
 
   ADDITIONAL_HEADERS
   AnnotationParser.h
   TaffoInitializerPass.h
+  IndirectCallPatcher.h
 )
 target_link_libraries(obj.${SELF} PUBLIC
   TaffoUtils

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -120,7 +120,7 @@ void taffo::manageIndirectCalls(llvm::Module &m) {
         auto *curCall = new CallSite(curCallInstruction);
         llvm::Function *curCallFunction = curCall->getCalledFunction();
 
-        if (isIndirectFunction(curCallFunction)) {
+        if (curCallFunction && isIndirectFunction(curCallFunction)) {
           handleIndirectCall(m, toDelete, curCallInstruction, curCall, curCallFunction);
         }
       }

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -169,8 +169,8 @@ const std::map<const std::string, handler_function> indirectCallFunctions = {
 //        {"__kmpc_omp_task", &handleCallToKmpcOmpTask}
 };
 
-void *handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
-                         const CallSite *curCall, Function *indirectFunction) {
+void handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
+                        const CallSite *curCall, Function *indirectFunction) {
   indirectCallFunctions.find(indirectFunction->getName())->second(m, toDelete, curCallInstruction, curCall,
                                                                   indirectFunction);
 }

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -1,0 +1,134 @@
+#include "IndirectCallPatcher.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/Support/CommandLine.h"
+#include <llvm/Transforms/Utils/ValueMapper.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/IR/IRBuilder.h>
+#include "TaffoInitializerPass.h"
+#include "TypeUtils.h"
+#include "Metadata.h"
+
+using namespace taffo;
+using namespace llvm;
+
+void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
+                    const CallSite *curCall, Function *indirectFunction) {
+  std::vector<Type *> paramsFunc;
+
+  auto functionType = indirectFunction->getFunctionType();
+
+  auto params = functionType->params();
+  paramsFunc.reserve(2);
+  for (auto i = 0; i < 2; i++) {
+    paramsFunc.push_back(params[i]);
+  }
+  //The third argument (outlined function) may not be inserted as an argument as it's completely managed from the newF body
+  for (auto i = 3; i < curCall->getNumArgOperands(); i++)
+    paramsFunc.push_back(curCall->getArgOperand(i)->getType());
+
+  auto newFunctionType = FunctionType::get(functionType->getReturnType(), paramsFunc, false);
+  auto newFunctionName = indirectFunction->getName() + "_trampoline";
+  Function *newF = Function::Create(
+          newFunctionType, indirectFunction->getLinkage(),
+          newFunctionName, indirectFunction->getParent());
+
+  for (auto i = 3; i < curCall->getNumArgOperands(); i++) {
+    // Shift back the argument name to set to take into account the skipped third argument
+    newF->getArg(i - 1)->setName(curCall->getArgOperand(i)->getName());
+  }
+
+  BasicBlock *block = BasicBlock::Create(m.getContext(), "main", newF);
+
+  auto microTaskOperand = dyn_cast<ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
+  auto microTaskFunction = dyn_cast<Function>(microTaskOperand);
+
+  std::vector<Value *> convArgs;
+  std::vector<Value *> trampolineArgs;
+
+  // Create null pointer to patch the internal OpenMP argument
+  Value *nullPointer = ConstantPointerNull::get(PointerType::get(Type::getInt32Ty(newF->getContext()), 0));
+  convArgs.push_back(nullPointer);
+  convArgs.push_back(nullPointer);
+
+  for (auto argIt = curCall->arg_begin(); argIt < curCall->arg_begin() + 2; argIt += 1) {
+    trampolineArgs.push_back(*argIt);
+  }
+  for (auto argIt = curCall->arg_begin() + 3; argIt < curCall->arg_end(); argIt += 1) {
+    convArgs.push_back(*argIt);
+    trampolineArgs.push_back(*argIt);
+  }
+
+  // Keep ref to the indirect function, preventing globaldce pass to destroy it
+  auto magicBitCast = new BitCastInst(indirectFunction, indirectFunction->getType(), "", block);
+  ReturnInst::Create(m.getContext(), nullptr, block);
+
+  std::vector<Value *> outlinedArgumentsInsideTrampoline;
+
+  outlinedArgumentsInsideTrampoline.push_back(nullPointer);
+  outlinedArgumentsInsideTrampoline.push_back(nullPointer);
+
+  for (auto argIt = newF->arg_begin() + 2; argIt < newF->arg_end(); argIt++) {
+    outlinedArgumentsInsideTrampoline.push_back(argIt);
+  }
+
+  CallInst *outlinedCall = CallInst::Create(microTaskFunction, outlinedArgumentsInsideTrampoline);
+  outlinedCall->insertAfter(magicBitCast);
+
+  CallInst *trampolineCallInstruction = CallInst::Create(newF, trampolineArgs);
+  trampolineCallInstruction->setCallingConv(curCallInstruction->getCallingConv());
+  trampolineCallInstruction->insertBefore(curCallInstruction);
+  trampolineCallInstruction->setDebugLoc(curCallInstruction->getDebugLoc());
+
+  MDNode *indirectFunctionRef = MDNode::get(curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
+  trampolineCallInstruction->setMetadata(INDIRECT_METADATA, indirectFunctionRef);
+
+  toDelete.push_back(curCallInstruction);
+  LLVM_DEBUG(dbgs() << "Newly created instruction: " << *trampolineCallInstruction << "\n");
+}
+
+const std::map<const std::string, handler_function> indirectCallFunctions = {
+        {"__kmpc_fork_call", &handleKmpcFork},
+//        {"__kmpc_omp_task_alloc", &handleCallToKmpcOmpTaskAlloc},
+//        {"__kmpc_omp_task", &handleCallToKmpcOmpTask}
+};
+
+void *handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
+                         const CallSite *curCall, Function *indirectFunction) {
+  indirectCallFunctions.find(indirectFunction->getName())->second(m, toDelete, curCallInstruction, curCall,
+                                                                  indirectFunction);
+}
+
+bool isIndirectFunction(llvm::Function *function) {
+  return indirectCallFunctions.count(function->getName());
+}
+
+void taffo::manageIndirectCalls(llvm::Module &m) {
+  LLVM_DEBUG(dbgs() << "Checking Indirect Calls" << "\n");
+
+  std::vector<Instruction *> toDelete;
+
+  for (llvm::Function &curFunction : m) {
+    for (auto instructionIt = inst_begin(curFunction); instructionIt != inst_end(curFunction); instructionIt++) {
+      if (auto curCallInstruction = dyn_cast<CallInst>(&(*instructionIt))) {
+        auto *curCall = new CallSite(curCallInstruction);
+        llvm::Function *curCallFunction = curCall->getCalledFunction();
+
+        if (isIndirectFunction(curCallFunction)) {
+          handleIndirectCall(m, toDelete, curCallInstruction, curCall, curCallFunction);
+        }
+      }
+    }
+  }
+
+  // Delete the Instructions in a separate loop
+  for (auto inst: toDelete) {
+    inst->eraseFromParent();
+  }
+}

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -155,6 +155,8 @@ void handleReduce(const Module &m, std::vector<Instruction *> &toDelete, CallIns
   MDNode *indirectFunctionRef = MDNode::get(curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
   trampolineCallInstruction->setMetadata(INDIRECT_METADATA, indirectFunctionRef);
 
+  curCallInstruction->replaceAllUsesWith(trampolineCallInstruction);
+
   toDelete.push_back(curCallInstruction);
   LLVM_DEBUG(dbgs() << "Newly created instruction: " << *trampolineCallInstruction << "\n");
 }
@@ -197,6 +199,6 @@ void taffo::manageIndirectCalls(llvm::Module &m) {
 
   // Delete the Instructions in a separate loop
   for (auto inst: toDelete) {
-    //inst->eraseFromParent(); # FIXME CHECK THE USAGE IN CASE OF NON-VOID FUNCTIONS
+    inst->eraseFromParent();
   }
 }

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -1,34 +1,39 @@
 #include "IndirectCallPatcher.h"
 
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/InstIterator.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/ADT/Statistic.h"
-#include "llvm/Support/CommandLine.h"
-#include <llvm/Transforms/Utils/ValueMapper.h>
-#include <llvm/Transforms/Utils/Cloning.h>
-#include <llvm/IR/IRBuilder.h>
+#include "Metadata.h"
 #include "TaffoInitializerPass.h"
 #include "TypeUtils.h"
-#include "Metadata.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Transforms/Utils/Cloning.h>
+#include <llvm/Transforms/Utils/ValueMapper.h>
 
 using namespace taffo;
 using namespace llvm;
 
-bool containsOmpTask(llvm::Function * function, int exploreDepth) {
-  for (auto instructionIt = inst_begin(function); instructionIt != inst_end(function); instructionIt++) {
-    if (auto curCallInstruction = dyn_cast<CallInst>(&(*instructionIt))) {
-      auto *curCall = new CallSite(curCallInstruction);
-      llvm::Function *curCallFunction = curCall->getCalledFunction();
+/// Check recursively whether an unsupported function is called.
+bool containsUnsupportedFunctions(llvm::Function *function, int exploreDepth) {
+  std::vector<std::string> prefixBlocklist{"__kmpc_omp_task"};
 
-      if (curCallFunction->getName().startswith("__kmpc_omp_task")) {
+  for (auto instructionIt = inst_begin(function);
+       instructionIt != inst_end(function); instructionIt++) {
+    if (auto curCallInstruction = dyn_cast<CallInst>(&(*instructionIt))) {
+      llvm::Function *curCallFunction = curCallInstruction->getCalledFunction();
+      auto functionName = curCallFunction->getName();
+
+      if (any_of(prefixBlocklist, [&](const std::string &prefix) {
+            return functionName.startswith(prefix);
+          })) {
         return true;
-      }
-      else if (exploreDepth > 0) {
-        if (containsOmpTask(curCallFunction, exploreDepth - 1)) {
+      } else if (exploreDepth > 0) {
+        if (containsUnsupportedFunctions(curCallFunction, exploreDepth - 1)) {
           return true;
         }
       }
@@ -37,12 +42,19 @@ bool containsOmpTask(llvm::Function * function, int exploreDepth) {
   return false;
 }
 
-void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
-                    const CallSite *curCall, Function *indirectFunction) {
-  auto microTaskOperand = dyn_cast<ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
+
+/// Handle the __kmpc_fork_call, by replacing the indirect call with a direct call to the function.
+/// In case an unsupported function is called, be conservative and keep the indirect function.
+void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete,
+                    CallInst *curCallInstruction, const CallSite *curCall,
+                    Function *indirectFunction) {
+  auto microTaskOperand =
+      dyn_cast<ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
   auto microTaskFunction = dyn_cast<Function>(microTaskOperand);
 
-  if (containsOmpTask(microTaskFunction, 1)) {
+  if (containsUnsupportedFunctions(microTaskFunction, 2)) {
+    LLVM_DEBUG(dbgs() << "Blocking the following conversion for unsupported functions"
+                      << *curCallInstruction << "\n");
     return;
   }
 
@@ -51,183 +63,112 @@ void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete, CallI
   auto functionType = indirectFunction->getFunctionType();
 
   auto params = functionType->params();
-  paramsFunc.reserve(2);
-  for (auto i = 0; i < 2; i++) {
-    paramsFunc.push_back(params[i]);
-  }
-  //The third argument (outlined function) may not be inserted as an argument as it's completely managed from the newF body
+  // Copy the first two params directly from the functionType since they fixed internal OpenMP parameters
+  copy_n(params.begin(), 2, back_inserter(paramsFunc));
+  // Skip the third argument (outlined function) and copy the dynamic arguments' types from the call
   for (auto i = 3; i < curCall->getNumArgOperands(); i++)
     paramsFunc.push_back(curCall->getArgOperand(i)->getType());
 
-  auto newFunctionType = FunctionType::get(functionType->getReturnType(), paramsFunc, false);
-  auto newFunctionName = indirectFunction->getName() + "_trampoline";
-  Function *newF = Function::Create(
-          newFunctionType, indirectFunction->getLinkage(),
-          newFunctionName, indirectFunction->getParent());
+  // Create the new function with the parsed types and signature
+  auto trampolineFunctionType =
+      FunctionType::get(functionType->getReturnType(), paramsFunc, false);
+  auto trampolineFunctionName = indirectFunction->getName() + "_trampoline";
+  Function *trampolineFunction =
+      Function::Create(trampolineFunctionType, indirectFunction->getLinkage(),
+                       trampolineFunctionName, indirectFunction->getParent());
 
+  // Shift back the argument name to set to take into account the skipped third argument
   for (auto i = 3; i < curCall->getNumArgOperands(); i++) {
-    // Shift back the argument name to set to take into account the skipped third argument
-    newF->getArg(i - 1)->setName(curCall->getArgOperand(i)->getName());
+    trampolineFunction->getArg(i - 1)->setName(curCall->getArgOperand(i)->getName());
   }
 
-  BasicBlock *block = BasicBlock::Create(m.getContext(), "main", newF);
 
+  BasicBlock *block = BasicBlock::Create(m.getContext(), "main", trampolineFunction);
 
-  std::vector<Value *> convArgs;
+  // Create the arguments of the trampoline function from the original call, skipping the third
   std::vector<Value *> trampolineArgs;
-
-  // Create null pointer to patch the internal OpenMP argument
-  Value *nullPointer = ConstantPointerNull::get(PointerType::get(Type::getInt32Ty(newF->getContext()), 0));
-  convArgs.push_back(nullPointer);
-  convArgs.push_back(nullPointer);
-
-  for (auto argIt = curCall->arg_begin(); argIt < curCall->arg_begin() + 2; argIt += 1) {
-    trampolineArgs.push_back(*argIt);
-  }
-  for (auto argIt = curCall->arg_begin() + 3; argIt < curCall->arg_end(); argIt += 1) {
-    convArgs.push_back(*argIt);
-    trampolineArgs.push_back(*argIt);
-  }
+  copy_n(curCall->arg_begin(), 2, back_inserter(trampolineArgs));
+  copy(curCall->arg_begin() + 3, curCall->arg_end(), back_inserter(trampolineArgs));
 
   // Keep ref to the indirect function, preventing globaldce pass to destroy it
-  auto magicBitCast = new BitCastInst(indirectFunction, indirectFunction->getType(), "", block);
+  auto magicBitCast =
+      new BitCastInst(indirectFunction, indirectFunction->getType(), "", block);
   ReturnInst::Create(m.getContext(), nullptr, block);
 
+  // Create the arguments of the direct function, extracted from the indirect one
   std::vector<Value *> outlinedArgumentsInsideTrampoline;
-
+  // Create null pointer to patch the internal OpenMP argument
+  Value *nullPointer = ConstantPointerNull::get(
+          PointerType::get(Type::getInt32Ty(trampolineFunction->getContext()), 0));
   outlinedArgumentsInsideTrampoline.push_back(nullPointer);
   outlinedArgumentsInsideTrampoline.push_back(nullPointer);
-
-  for (auto argIt = newF->arg_begin() + 2; argIt < newF->arg_end(); argIt++) {
+  for (auto argIt = trampolineFunction->arg_begin() + 2; argIt < trampolineFunction->arg_end(); argIt++) {
     outlinedArgumentsInsideTrampoline.push_back(argIt);
   }
 
-  CallInst *outlinedCall = CallInst::Create(microTaskFunction, outlinedArgumentsInsideTrampoline);
+  // Create the call to the direct function inside the trampoline
+  CallInst *outlinedCall =
+      CallInst::Create(microTaskFunction, outlinedArgumentsInsideTrampoline);
   outlinedCall->insertAfter(magicBitCast);
 
-  CallInst *trampolineCallInstruction = CallInst::Create(newF, trampolineArgs);
-  trampolineCallInstruction->setCallingConv(curCallInstruction->getCallingConv());
+  // Create the call to the trampoline function after the indirect function
+  CallInst *trampolineCallInstruction = CallInst::Create(trampolineFunction, trampolineArgs);
+  trampolineCallInstruction->setCallingConv(
+      curCallInstruction->getCallingConv());
   trampolineCallInstruction->insertBefore(curCallInstruction);
   trampolineCallInstruction->setDebugLoc(curCallInstruction->getDebugLoc());
 
-  MDNode *indirectFunctionRef = MDNode::get(curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
-  trampolineCallInstruction->setMetadata(INDIRECT_METADATA, indirectFunctionRef);
+  MDNode *indirectFunctionRef = MDNode::get(
+      curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
+  trampolineCallInstruction->setMetadata(INDIRECT_METADATA,
+                                         indirectFunctionRef);
 
+  // Save the old instruction to delete it later
   toDelete.push_back(curCallInstruction);
-  LLVM_DEBUG(dbgs() << "Newly created instruction: " << *trampolineCallInstruction << "\n");
+  LLVM_DEBUG(dbgs() << "Newly created instruction: "
+                    << *trampolineCallInstruction << "\n");
 }
 
-void handleReduce(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
-                    const CallSite *curCall, Function *indirectFunction) {
-  auto microTaskFunction = dyn_cast<Function>(curCall->arg_begin() + 5);
-
-  if (containsOmpTask(microTaskFunction, 1)) {
-    return;
-  }
-
-  std::vector<Type *> paramsFunc;
-
-  auto functionType = indirectFunction->getFunctionType();
-
-  auto params = functionType->params();
-  paramsFunc.reserve(2);
-  for (auto i = 0; i < 4; i++) {
-    paramsFunc.push_back(params[i]);
-  }
-  for (auto i = 4; i < curCall->getNumArgOperands(); i++) {
-    paramsFunc.push_back(curCall->getArgOperand(i)->getType());
-  }
-
-  auto newFunctionType = FunctionType::get(functionType->getReturnType(), paramsFunc, false);
-  auto newFunctionName = indirectFunction->getName() + "_trampoline";
-  Function *newF = Function::Create(
-          newFunctionType, indirectFunction->getLinkage(),
-          newFunctionName, indirectFunction->getParent());
-
-  BasicBlock *block = BasicBlock::Create(m.getContext(), "main", newF);
-
-
-
-  std::vector<Value *> convArgs;
-  std::vector<Value *> trampolineArgs;
-
-  // Create null pointer to patch the internal OpenMP argument
-  Value *nullPointer = ConstantPointerNull::get(PointerType::get(Type::getInt32Ty(newF->getContext()), 0));
-  convArgs.push_back(nullPointer);
-  convArgs.push_back(nullPointer);
-
-  for (auto argIt = curCall->arg_begin(); argIt < curCall->arg_begin() + 4; argIt += 1) {
-    trampolineArgs.push_back(*argIt);
-  }
-  for (auto argIt = curCall->arg_begin() + 4; argIt < curCall->arg_end(); argIt += 1) {
-    convArgs.push_back(*argIt);
-    trampolineArgs.push_back(*argIt);
-  }
-
-  // Keep ref to the indirect function, preventing globaldce pass to destroy it
-  auto magicBitCast = new BitCastInst(indirectFunction, indirectFunction->getType(), "", block);
-  ReturnInst::Create(m.getContext(), llvm::ConstantInt::get(llvm::Type::getInt32Ty(m.getContext()), 2), block);
-
-  std::vector<Value *> outlinedArgumentsInsideTrampoline;
-
-  outlinedArgumentsInsideTrampoline.push_back(newF->arg_begin() + 4);
-  outlinedArgumentsInsideTrampoline.push_back(newF->arg_begin() + 4);
-
-  CallInst *outlinedCall = CallInst::Create(microTaskFunction, outlinedArgumentsInsideTrampoline);
-  outlinedCall->insertAfter(magicBitCast);
-
-  CallInst *trampolineCallInstruction = CallInst::Create(newF, trampolineArgs);
-  trampolineCallInstruction->setCallingConv(curCallInstruction->getCallingConv());
-  trampolineCallInstruction->insertBefore(curCallInstruction);
-  trampolineCallInstruction->setDebugLoc(curCallInstruction->getDebugLoc());
-
-  MDNode *indirectFunctionRef = MDNode::get(curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
-  trampolineCallInstruction->setMetadata(INDIRECT_METADATA, indirectFunctionRef);
-
-  curCallInstruction->replaceAllUsesWith(trampolineCallInstruction);
-
-  toDelete.push_back(curCallInstruction);
-  LLVM_DEBUG(dbgs() << "Newly created instruction: " << *trampolineCallInstruction << "\n");
-}
-
+/// Map to keep track of the handled indirect functions.
 const std::map<const std::string, handler_function> indirectCallFunctions = {
-        {"__kmpc_fork_call", &handleKmpcFork},
-        {"__kmpc_reduce_nowait", &handleReduce},
-        {"__kmpc_reduce", &handleReduce}
-//        {"__kmpc_omp_task_alloc", &handleCallToKmpcOmpTaskAlloc},
-//        {"__kmpc_omp_task", &handleCallToKmpcOmpTask}
+    {"__kmpc_fork_call", &handleKmpcFork},
 };
 
-void handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete, CallInst *curCallInstruction,
-                        const CallSite *curCall, Function *indirectFunction) {
-  indirectCallFunctions.find(indirectFunction->getName())->second(m, toDelete, curCallInstruction, curCall,
-                                                                  indirectFunction);
+/// Check if the given call is indirect, using the related handler.
+void handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete,
+                        CallInst *curCallInstruction, const CallSite *curCall,
+                        Function *indirectFunction) {
+  auto indirectCallHandler = indirectCallFunctions.find(indirectFunction->getName());
+
+  if (indirectCallHandler != indirectCallFunctions.end())
+    indirectCallHandler->second(m, toDelete, curCallInstruction, curCall, indirectFunction);
 }
 
-bool isIndirectFunction(llvm::Function *function) {
-  return indirectCallFunctions.count(function->getName());
-}
 
+/// Check indirect calls in the given module, and handle then.
 void taffo::manageIndirectCalls(llvm::Module &m) {
-  LLVM_DEBUG(dbgs() << "Checking Indirect Calls" << "\n");
+  LLVM_DEBUG(dbgs() << "Checking Indirect Calls"
+                    << "\n");
 
   std::vector<Instruction *> toDelete;
 
   for (llvm::Function &curFunction : m) {
-    for (auto instructionIt = inst_begin(curFunction); instructionIt != inst_end(curFunction); instructionIt++) {
+    for (auto instructionIt = inst_begin(curFunction);
+         instructionIt != inst_end(curFunction); instructionIt++) {
       if (auto curCallInstruction = dyn_cast<CallInst>(&(*instructionIt))) {
         auto *curCall = new CallSite(curCallInstruction);
         llvm::Function *curCallFunction = curCall->getCalledFunction();
 
-        if (curCallFunction && isIndirectFunction(curCallFunction)) {
-          handleIndirectCall(m, toDelete, curCallInstruction, curCall, curCallFunction);
+        if (curCallFunction) {
+          handleIndirectCall(m, toDelete, curCallInstruction, curCall,
+                             curCallFunction);
         }
       }
     }
   }
 
-  // Delete the Instructions in a separate loop
-  for (auto inst: toDelete) {
+  // Delete the saved instructions in a separate loop to avoid conflicts in the iterator
+  for (auto inst : toDelete) {
     inst->eraseFromParent();
   }
 }

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -22,7 +22,8 @@ using namespace llvm;
 /// Check recursively whether an unsupported function is called.
 bool containsUnsupportedFunctions(
     const llvm::Function *function,
-    std::unordered_set<Function *> traversedFunctions) {
+    std::unordered_set<Function *> traversedFunctions)
+{
   static const std::vector<std::string> prefixBlocklist{"__kmpc_omp_task",
                                                         "__kmpc_reduce"};
 
@@ -53,7 +54,8 @@ bool containsUnsupportedFunctions(
 /// attach the OMP disabled metadata to the the shared variables.
 void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete,
                     CallInst *curCallInstruction, const CallSite *curCall,
-                    Function *indirectFunction) {
+                    Function *indirectFunction)
+{
   auto microTaskOperand =
       dyn_cast<ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
   auto microTaskFunction = dyn_cast_or_null<Function>(microTaskOperand);
@@ -167,7 +169,8 @@ const std::map<const std::string, handler_function> indirectCallFunctions = {
 /// Check if the given call is indirect, using the related handler.
 void handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete,
                         CallInst *curCallInstruction, const CallSite *curCall,
-                        Function *indirectFunction) {
+                        Function *indirectFunction)
+{
   auto indirectCallHandler =
       indirectCallFunctions.find(indirectFunction->getName());
 
@@ -177,7 +180,8 @@ void handleIndirectCall(const Module &m, std::vector<Instruction *> &toDelete,
 }
 
 /// Check indirect calls in the given module, and handle then.
-void taffo::manageIndirectCalls(llvm::Module &m) {
+void taffo::manageIndirectCalls(llvm::Module &m)
+{
   LLVM_DEBUG(dbgs() << "Checking Indirect Calls"
                     << "\n");
 

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -1,8 +1,4 @@
-#include "IndirectCallPatcher.h"
-
-#include "Metadata.h"
-#include "TaffoInitializerPass.h"
-#include "TypeUtils.h"
+#include <unordered_set>
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
@@ -14,7 +10,10 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
-#include <unordered_set>
+#include "IndirectCallPatcher.h"
+#include "Metadata.h"
+#include "TaffoInitializerPass.h"
+#include "TypeUtils.h"
 
 using namespace taffo;
 using namespace llvm;

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -6,14 +6,14 @@
 #include "llvm/ADT/Statistic.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include <llvm/IR/IRBuilder.h>
-#include <llvm/Transforms/Utils/Cloning.h>
-#include <llvm/Transforms/Utils/ValueMapper.h>
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
 
 using namespace taffo;
 using namespace llvm;

--- a/TaffoInitializer/IndirectCallPatcher.cpp
+++ b/TaffoInitializer/IndirectCallPatcher.cpp
@@ -60,12 +60,10 @@ void handleKmpcFork(const Module &m, std::vector<Instruction *> &toDelete,
       dyn_cast<ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
   auto microTaskFunction = dyn_cast_or_null<Function>(microTaskOperand);
 
-  if (microTaskFunction == nullptr) {
-    LLVM_DEBUG(dbgs() << "Blocking the following conversion for failed "
-                         "dyn_cast on the OpenMP microTask"
-                      << *curCallInstruction << "\n");
-    return;
-  }
+  assert(
+          microTaskFunction != nullptr &&
+          "The microtask function must be present in the __kmpc_fork_call as a "
+          "third argument");
 
   if (containsUnsupportedFunctions(microTaskFunction, {})) {
     LLVM_DEBUG(dbgs() << "Blocking conversion for shared variables in "

--- a/TaffoInitializer/IndirectCallPatcher.h
+++ b/TaffoInitializer/IndirectCallPatcher.h
@@ -1,9 +1,9 @@
 #ifndef TAFFO_INDIRECTCALLPATCHER_H
 #define TAFFO_INDIRECTCALLPATCHER_H
 
+#include <list>
 #include "llvm/IR/CallSite.h"
 #include "llvm/IR/Dominators.h"
-#include <list>
 
 namespace taffo {
 

--- a/TaffoInitializer/IndirectCallPatcher.h
+++ b/TaffoInitializer/IndirectCallPatcher.h
@@ -1,9 +1,9 @@
 #ifndef TAFFO_INDIRECTCALLPATCHER_H
 #define TAFFO_INDIRECTCALLPATCHER_H
 
+#include "llvm/IR/CallSite.h"
 #include "llvm/IR/Dominators.h"
 #include <list>
-#include <llvm/IR/CallSite.h>
 
 namespace taffo {
 

--- a/TaffoInitializer/IndirectCallPatcher.h
+++ b/TaffoInitializer/IndirectCallPatcher.h
@@ -7,15 +7,14 @@
 
 namespace taffo {
 
-    /** Function type for handlers **/
-    using handler_function = void(*)(const llvm::Module &m, std::vector<llvm::Instruction *> &toDelete, llvm::CallInst *curCallInstruction,
-                                     const llvm::CallSite *curCall, llvm::Function *indirectFunction);
+/** Function type for handlers **/
+using handler_function = void (*)(const llvm::Module &m,
+                                  std::vector<llvm::Instruction *> &toDelete,
+                                  llvm::CallInst *curCallInstruction,
+                                  const llvm::CallSite *curCall,
+                                  llvm::Function *indirectFunction);
 
-    /** Latest allocated task name **/
-    extern llvm::Function* allocatedTask;
-
-    void manageIndirectCalls(llvm::Module &m);
-}
+void manageIndirectCalls(llvm::Module &m);
+} // namespace taffo
 
 #endif TAFFO_INDIRECTCALLPATCHER_H
-

--- a/TaffoInitializer/IndirectCallPatcher.h
+++ b/TaffoInitializer/IndirectCallPatcher.h
@@ -7,13 +7,8 @@
 
 namespace taffo {
 
-/** Function type for handlers **/
-using handler_function = void (*)(const llvm::Module &m,
-                                  std::vector<llvm::Instruction *> &toDelete,
-                                  llvm::CallInst *curCallInstruction,
-                                  const llvm::CallSite *curCall,
-                                  llvm::Function *indirectFunction);
-
+/// Check whether indirect calls are present in the given module, and patch them with dedicated trampoline calls.
+/// The trampolines enable subsequent passes to better analyze the indirect calls.
 void manageIndirectCalls(llvm::Module &m);
 } // namespace taffo
 

--- a/TaffoInitializer/IndirectCallPatcher.h
+++ b/TaffoInitializer/IndirectCallPatcher.h
@@ -1,0 +1,21 @@
+#ifndef TAFFO_INDIRECTCALLPATCHER_H
+#define TAFFO_INDIRECTCALLPATCHER_H
+
+#include "llvm/IR/Dominators.h"
+#include <list>
+#include <llvm/IR/CallSite.h>
+
+namespace taffo {
+
+    /** Function type for handlers **/
+    using handler_function = void(*)(const llvm::Module &m, std::vector<llvm::Instruction *> &toDelete, llvm::CallInst *curCallInstruction,
+                                     const llvm::CallSite *curCall, llvm::Function *indirectFunction);
+
+    /** Latest allocated task name **/
+    extern llvm::Function* allocatedTask;
+
+    void manageIndirectCalls(llvm::Module &m);
+}
+
+#endif TAFFO_INDIRECTCALLPATCHER_H
+

--- a/TaffoInitializer/TaffoInitializerPass.cpp
+++ b/TaffoInitializer/TaffoInitializerPass.cpp
@@ -1,7 +1,5 @@
-#include "TaffoInitializerPass.h"
-#include "IndirectCallPatcher.h"
-#include "Metadata.h"
-#include "TypeUtils.h"
+#include <climits>
+#include <cmath>
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -19,8 +17,10 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
-#include <climits>
-#include <cmath>
+#include "IndirectCallPatcher.h"
+#include "Metadata.h"
+#include "TaffoInitializerPass.h"
+#include "TypeUtils.h"
 
 using namespace llvm;
 using namespace taffo;

--- a/TaffoInitializer/TaffoInitializerPass.cpp
+++ b/TaffoInitializer/TaffoInitializerPass.cpp
@@ -107,7 +107,11 @@ void TaffoInitializer::setMetadataOfValue(Value *v, ValueInfo& vi)
     if (vi.target.hasValue())
       mdutils::MetadataManager::setTargetMetadata(*inst, vi.target.getValue());
 
-    if (mdutils::InputInfo *ii = dyn_cast<mdutils::InputInfo>(md.get())) {
+    if (auto *ii = dyn_cast<mdutils::InputInfo>(md.get())) {
+      if (inst->getMetadata(OMP_DISABLED_METADATA)) {
+        LLVM_DEBUG(dbgs() << "Blocking conversion for shared variable" << *inst << "\n");
+        ii->IEnableConversion = false;
+      }
       mdutils::MetadataManager::setInputInfoMetadata(*inst, *ii);
     } else if (mdutils::StructInfo *si = dyn_cast<mdutils::StructInfo>(md.get())) {
       mdutils::MetadataManager::setStructInfoMetadata(*inst, *si);

--- a/TaffoInitializer/TaffoInitializerPass.cpp
+++ b/TaffoInitializer/TaffoInitializerPass.cpp
@@ -1,27 +1,26 @@
-#include <cmath>
-#include <climits>
-#include "llvm/Pass.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/Function.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/InstrTypes.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/ADT/Statistic.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/raw_ostream.h"
-#include <llvm/Transforms/Utils/ValueMapper.h>
-#include <llvm/Transforms/Utils/Cloning.h>
-#include <llvm/IR/IRBuilder.h>
 #include "TaffoInitializerPass.h"
 #include "IndirectCallPatcher.h"
-#include "TypeUtils.h"
 #include "Metadata.h"
-
+#include "TypeUtils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/Statistic.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
+#include <climits>
+#include <cmath>
 
 using namespace llvm;
 using namespace taffo;

--- a/TaffoInitializer/TaffoInitializerPass.cpp
+++ b/TaffoInitializer/TaffoInitializerPass.cpp
@@ -515,14 +515,13 @@ Function* TaffoInitializer::createFunctionAndQueue(llvm::CallSite *call, ConvQue
   LLVM_DEBUG(dbgs() << "Create function from " << oldF->getName() << " to " << newF->getName() << "\n");
   LLVM_DEBUG(dbgs() << "  callsite instr " << *call->getInstruction() << " [" << call->getInstruction()->getFunction()->getName() << "]\n");
   for (int i=0; oldArgumentI != oldF->arg_end() ; oldArgumentI++, newArgumentI++, i++) {
-    Value *callOperand = call->getInstruction()->getOperand(i);
-
     auto user_begin = newArgumentI->user_begin();
     if (user_begin == newArgumentI->user_end()) {
-      LLVM_DEBUG(dbgs() << "  Arg nr. " << i << " skipped, callOperand has no valueInfo\n");
+      LLVM_DEBUG(dbgs() << "  Arg nr. " << i << " skipped, value has no uses\n");
       continue;
     }
 
+    Value *callOperand = call->getInstruction()->getOperand(i);
     Value *allocaOfArgument = user_begin->getOperand(1);
     if (!isa<AllocaInst>(allocaOfArgument))
       allocaOfArgument = nullptr;

--- a/TaffoInitializer/TaffoInitializerPass.cpp
+++ b/TaffoInitializer/TaffoInitializerPass.cpp
@@ -18,6 +18,7 @@
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/IR/IRBuilder.h>
 #include "TaffoInitializerPass.h"
+#include "IndirectCallPatcher.h"
 #include "TypeUtils.h"
 #include "Metadata.h"
 
@@ -38,101 +39,12 @@ static RegisterPass<TaffoInitializer> X(
 llvm::cl::opt<bool> ManualFunctionCloning("manualclone",
     llvm::cl::desc("Enables function cloning only for annotated functions"), llvm::cl::init(false));
 
-// TODO Use map to handle different indirect functions
-void removeOpenMPIndirection(llvm::Module &m)
-{
-  LLVM_DEBUG(dbgs() << "Removing indirection OpenMP "  << "\n");
-  std::vector<Instruction *> toDelete;
-  for (llvm::Function &curFunction : m) {
-    for (auto instructionIt = inst_begin(curFunction); instructionIt != inst_end(curFunction); instructionIt++) {
-      if (auto curCallInstruction = dyn_cast<CallInst>(&(*instructionIt))) {
-        auto *curCall = new CallSite(curCallInstruction);
-        llvm::Function* indirectFunction = curCall->getCalledFunction();
-
-        if (indirectFunction->getName() == "__kmpc_fork_call") {
-          std::vector<Type *> paramsFunc;
-
-          auto functionType = indirectFunction->getFunctionType();
-
-          auto params = functionType->params();
-          for (auto i = 0; i < 2; i++) {
-            paramsFunc.push_back(params[i]);
-          }
-          //The third argument (outlined function) may not be inserted as an argument as it's completely managed from the newF body
-          for (auto i = 3; i < curCall->getNumArgOperands(); i++)
-            paramsFunc.push_back(curCall->getArgOperand(i)->getType());
-
-          auto newFunctionType = FunctionType::get(functionType->getReturnType(), paramsFunc, false);
-          Function *newF = Function::Create(
-                  newFunctionType, indirectFunction->getLinkage(),
-                  indirectFunction->getName() + "_trampoline", indirectFunction->getParent());
-
-          for (auto i = 3; i < curCall->getNumArgOperands(); i++){
-            newF->getArg(i-1)->setName(curCall->getArgOperand(i)->getName());
-          }
-
-          BasicBlock* block = BasicBlock::Create(m.getContext(), "main", newF);
-
-          auto microTaskOperand = llvm::dyn_cast<llvm::ConstantExpr>(curCall->arg_begin() + 2)->getOperand(0);
-          auto microTaskFunction = llvm::dyn_cast<llvm::Function>(microTaskOperand);
-
-          std::vector<Value *> convArgs;
-          std::vector<Value *> trampolineArgs;
-
-          // Create null pointer to patch the internal OpenMP argument
-          Value *nullPointer = ConstantPointerNull::get(PointerType::get(Type::getInt32Ty(newF->getContext()), 0));
-          convArgs.push_back(nullPointer);
-          convArgs.push_back(nullPointer);
-
-          for (auto argIt = curCall->arg_begin(); argIt < curCall->arg_begin() + 2; argIt += 1) {
-            trampolineArgs.push_back(*argIt);
-          }
-          for (auto argIt = curCall->arg_begin() +3; argIt < curCall->arg_end(); argIt += 1) {
-            convArgs.push_back(*argIt);
-            trampolineArgs.push_back(*argIt);
-          }
-
-          // Keep ref to the indirect function, preventing globaldce pass to destroy it
-          auto magicBitCast = new llvm::BitCastInst(indirectFunction, indirectFunction->getType(), "", block);
-          ReturnInst::Create(m.getContext(), nullptr, block);
-
-          std::vector<Value *> outlinedArgumentsInsideTrampoline;
-
-          outlinedArgumentsInsideTrampoline.push_back(nullPointer);
-          outlinedArgumentsInsideTrampoline.push_back(nullPointer);
-
-          for (auto argIt = newF->arg_begin() + 2; argIt < newF->arg_end(); argIt ++) {
-            outlinedArgumentsInsideTrampoline.push_back(argIt);
-          }
-
-          CallInst *outlinedCall = CallInst::Create(microTaskFunction, outlinedArgumentsInsideTrampoline);
-          outlinedCall->insertAfter(magicBitCast);
-
-          CallInst *trampolineCallInstruction = CallInst::Create(newF, trampolineArgs);
-          trampolineCallInstruction->setCallingConv(curCallInstruction->getCallingConv());
-          trampolineCallInstruction->insertBefore(curCallInstruction);
-          trampolineCallInstruction->setDebugLoc(curCallInstruction->getDebugLoc());
-
-          MDNode *indirectFunctionRef = MDNode::get(curCallInstruction->getContext(), ValueAsMetadata::get(indirectFunction));
-          trampolineCallInstruction->setMetadata(OPENMP_INDIRECT_METADATA, indirectFunctionRef);
-
-          toDelete.push_back(curCallInstruction);
-
-          LLVM_DEBUG(dbgs() << "Newly created instruction: " << *trampolineCallInstruction << "\n");
-        }
-      }
-    }
-  }
-  for (auto inst: toDelete) {
-    inst->eraseFromParent();
-  }
-}
 
 bool TaffoInitializer::runOnModule(Module &m)
 {
   DEBUG_WITH_TYPE(DEBUG_ANNOTATION, printAnnotatedObj(m));
 
-  removeOpenMPIndirection(m);
+  manageIndirectCalls(m);
 
   ConvQueueT local;
   ConvQueueT global;


### PR DESCRIPTION
# TAFFO x OpenMP

This PR is one of four PRs concerning the integration of TAFFO with OpenMP:
1. Initializer PR, patching the runtime OpenMP library functions with a trampoline call 
2. Conversion PR, re-creating the correct runtime OpenMP library functions from the trampoline calls, after the conversion in fixed points (https://github.com/HEAPLab/TAFFO-submodule-conv/pull/4)
3. Test PR, with tests and the integration of the [PolyBench-ACC benchmark](https://github.com/cavazos-lab/PolyBench-ACC) (https://github.com/HEAPLab/TAFFO-test/pull/2)
4. TAFFO high-level PR, with the technical documentation (https://github.com/HEAPLab/TAFFO/pull/4)

## Summary
The PR adds an IndirectCallPatcher header and source file, removing the indirection in the OpenMP library functions and enabling subsequent passes to analyze and optimize the parallel code regions.